### PR TITLE
Update artifacts-guidance based on proposed changes

### DIFF
--- a/artifacts-guidance.md
+++ b/artifacts-guidance.md
@@ -1,5 +1,9 @@
 # Guidance for Artifacts Authors
 
 Content other than OCI container images MAY be packaged using the image manifest.
-When this is done, the `config.mediaType` value MUST be set to a value specific to the artifact type or the [empty value](manifest.md#guidance-for-an-empty-descriptor).
+When this is done, 
+
+ - `image.artifactType` value MUST be set to a value specific to the artifact type.
+ - `config.mediaType` value must be set to [empty value](manifest.md#guidance-for-an-empty-descriptor).
+
 Additional details and examples are provided in the [image manifest specification](manifest.md#guidelines-for-artifact-usage).


### PR DESCRIPTION
Update guidance based on proposed changes https://opencontainers.org/posts/blog/2023-07-07-summary-of-upcoming-changes-in-oci-image-and-distribution-specs-v-1-1/

This is on the assumption that `image.artifactType` field is now the preferred way to denote artefact types that are not images.